### PR TITLE
FIX: rollback connection when autoCommit==true when closing the connection

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
@@ -219,6 +219,9 @@ final class PooledConnection extends ConnectionDelegator {
       }
     }
     try {
+      if (!connection.getAutoCommit()) {
+        connection.rollback();
+      }
       connection.close();
       pool.dec();
     } catch (SQLException ex) {


### PR DESCRIPTION
DB2 does not allow closing connections with autoCommit==true which have not either commitet or rolled back. This occurs when connections have not been used at all or e.g. only been used for the heartbeat (with validate).