### PR TITLE
FIX: Cancel statement before closing to avoid leaking connections

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/ExtendedPreparedStatement.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/ExtendedPreparedStatement.java
@@ -14,6 +14,7 @@ import java.sql.Ref;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
@@ -60,7 +61,15 @@ final class ExtendedPreparedStatement extends ExtendedStatement implements Prepa
    * reuse the PreparedStatement.
    */
   void closeDestroy() throws SQLException {
-    delegate.close();
+    if (!delegate.isClosed()) {
+      // Cancel might throw an exception when it is already closed
+      try {
+        delegate.cancel();
+      } catch (SQLFeatureNotSupportedException e) {
+        Log.trace("Canceling statement not supported by JDBC-driver");
+      }
+      delegate.close();
+    }
   }
 
   /**


### PR DESCRIPTION
Situation: Trying to close busy connections, we first have to close the statements which have run and might currently be running over the connection. For DB2 we first have to call cancel on the statement, in order for it to actually stop and the executing thread to be notified.