### PR TITLE
Bugfix/allow recovering from reset with busy connections

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnectionQueue.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnectionQueue.java
@@ -227,8 +227,8 @@ final class PooledConnectionQueue {
       // are other threads already waiting? (they get priority)
       if (waitingThreads == 0
         // If datasource is down, we might run into _obtainConnectionWaitLoop forever (or until no thread requests connections),
-        // in case all connections were busy on reset(). Without this, it would be hard to recover/reconnect the pool
-        || !pool.isDataSourceUp()) {
+        // in case threads were waiting when reset() occurs. Without this, it would be hard to recover/reconnect the pool.
+        || busyList.size() < maxSize) {
         PooledConnection freeConnection = extractFromFreeList();
         if (freeConnection != null) {
           return freeConnection;

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnectionQueue.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnectionQueue.java
@@ -225,7 +225,10 @@ final class PooledConnectionQueue {
       // or SQLException but that is ok as its only an indicator
       hitCount++;
       // are other threads already waiting? (they get priority)
-      if (waitingThreads == 0) {
+      if (waitingThreads == 0
+        // If datasource is down, we might run into _obtainConnectionWaitLoop forever (or until no thread requests connections),
+        // in case all connections were busy on reset(). Without this, it would be hard to recover/reconnect the pool
+        || !pool.isDataSourceUp()) {
         PooledConnection freeConnection = extractFromFreeList();
         if (freeConnection != null) {
           return freeConnection;


### PR DESCRIPTION
When dataSource was closed with threads waiting for connections, it might be really hard to recover, because we might always run into the code looking to find free connections in the freeConnectionsList, but can't since no code would put any connections into that list.